### PR TITLE
src/Lib: use foldMap Sum to eliminate the [] special case

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -20,6 +20,7 @@ import Graphics.Rendering.Chart.Easy as E
 import Graphics.Rendering.Chart.Backend.Diagrams (toFile)
 
 -- Haskell stuff
+import Data.Monoid (Sum(..))
 import Data.Ratio
 
 -- Beginners luck stuff
@@ -99,11 +100,10 @@ ema (EMA prevEMA) candles@(candle:_) = EMA ((getClosePrice candle - prevEMA) * m
 
 -- | Simple moving average over an array of candles
 sma :: [CoinbaseCandle] -> SMA
-sma [] = SMA 0 
 sma candles = SMA (totalSum candles / numCandles candles)
   where
-    totalSum = (sum . map getClosePrice)
-    numCandles = (fromIntegral . length)
+    totalSum = getSum . foldMap (Sum . getClosePrice)
+    numCandles = fromIntegral . length
 
 -- | Using the old world data computes the next exponential moving average values
 getNextWindow :: World -> IO World


### PR DESCRIPTION
`sum` by default is an impartial function, which requires you to special-case the empty list like you've done here. It's a terrible member of the default prelude. However, with Monoids, you can get a nice total function in the form of `foldMap Sum`. The downside is that you then have to un-wrap the `Sum` newtype when you're done with it (unless you get [fancy](https://hackage.haskell.org/package/lens-4.15.4/docs/Control-Lens-Wrapped.html)).