### PR TITLE
Making any sort of http request is unsafe, catch the errors

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -20,6 +20,7 @@ import Coinbase.Exchange.Types
 import Data.Time.Clock
 
 -- Haskell stuff
+import System.IO.Error
 
 -- Beginners luck stuff
 import Types
@@ -78,7 +79,9 @@ sma candles = SMA (totalSum candles / numCandles candles)
 
 -- | Using the old window data computes the next exponential moving average values
 getNextWindow :: ExchangeConf -> Window -> IO Window
-getNextWindow config oldWindow@(Window (shortEMA, longEMA) _) = do
+getNextWindow config oldWindow@(Window (shortEMA, longEMA) _) =
+  {- Making request to API will throw exception if over rate limit, just try again -}
+  flip catchIOError (\_ -> putStrLn "Failed request" >> return oldWindow) $ do
   {- Request info from GDAX API -}
   eitherShortCandles <- getMostRecentCandles config shortNumCandles candleLength
   eitherLongCandles <- getMostRecentCandles config longNumCandles candleLength


### PR DESCRIPTION
[Coinbase API requests](https://github.com/AndrewRademacher/coinbase-exchange/blob/master/src/Coinbase/Exchange/Rest.hs) rely on [the `http` method here](https://hackage.haskell.org/package/http-conduit-1.2.1/docs/src/Network-HTTP-Conduit.html#http) which uses `throwIO`. Sketchy stuff. Refactor to catch the error. 

@archerwheeler @DylanRJohnston @frances-h 